### PR TITLE
Clean up certificate stack name

### DIFF
--- a/iac/stages/global_bootstrap.py
+++ b/iac/stages/global_bootstrap.py
@@ -42,6 +42,6 @@ class GlobalBootstrap(cdk.Stage):
 
         stacks.Certificate(
             self,
-            f"{construct_id}-Certificate",
+            "CertificateStack",
             domain_name=domain_name,
         )

--- a/tests/unit/stages/test_global_bootstrap.py
+++ b/tests/unit/stages/test_global_bootstrap.py
@@ -19,4 +19,4 @@ def test_child_count(stage: stages.GlobalBootstrap) -> None:
 
 
 def test_has_certificate(stage: stages.GlobalBootstrap) -> None:
-    assert stage.node.find_child("GlobalBootstrap-Certificate")
+    assert stage.node.find_child("CertificateStack")


### PR DESCRIPTION
The certificate stack was deploying as `yyyymmddblog-GlobalBootstrap-yyyymmddblog-GlobalBootstrap-Certificate`.

This change shortens it to `yyyymmddblog-GlobalBootstrap-Certificate`.